### PR TITLE
Added  integration with native `jax` instruments

### DIFF
--- a/pogema/grid_config.py
+++ b/pogema/grid_config.py
@@ -1,14 +1,16 @@
 import sys
 from typing import Optional, Union
+
 from pydantic import BaseModel, validator
+from typing_extensions import Literal
 
 from pogema.utils import CommonSettings
 
-from typing_extensions import Literal
 
-
-class GridConfig(CommonSettings, ):
-    on_target: Literal['finish', 'nothing', 'restart'] = 'finish'
+class GridConfig(
+    CommonSettings,
+):
+    on_target: Literal["finish", "nothing", "restart"] = "finish"
     seed: Optional[int] = None
     size: int = 8
     density: float = 0.3
@@ -16,76 +18,93 @@ class GridConfig(CommonSettings, ):
     obs_radius: int = 5
     agents_xy: Optional[list] = None
     targets_xy: Optional[list] = None
-    collision_system: Literal['block_both', 'priority', 'soft'] = 'priority'
+    collision_system: Literal["block_both", "priority", "soft"] = "priority"
     persistent: bool = False
-    observation_type: Literal['POMAPF', 'MAPF', 'default'] = 'default'
+    observation_type: Literal["POMAPF", "MAPF", "default"] = "default"
     map: Union[list, str] = None
 
     map_name: str = None
 
-    integration: Literal['SampleFactory', 'PyMARL', 'rllib', 'gym', 'PettingZoo'] = None
+    integration: Literal[
+        "SampleFactory", "PyMARL", "rllib", "gym", "PettingZoo", "jax"
+    ] = None
     max_episode_steps: int = 64
     auto_reset: Optional[bool] = None
 
-    @validator('seed')
+    @validator("seed")
     def seed_initialization(cls, v):
-        assert v is None or (0 <= v < sys.maxsize), "seed must be in [0, " + str(sys.maxsize) + ']'
+        assert v is None or (0 <= v < sys.maxsize), (
+            "seed must be in [0, " + str(sys.maxsize) + "]"
+        )
         return v
 
-    @validator('size')
+    @validator("size")
     def size_restrictions(cls, v):
         assert 2 <= v <= 1024, "size must be in [2, 1024]"
         return v
 
-    @validator('density')
+    @validator("density")
     def density_restrictions(cls, v):
         assert 0.0 <= v <= 1, "density must be in [0, 1]"
         return v
 
-    @validator('num_agents')
+    @validator("num_agents")
     def num_agents_must_be_positive(cls, v):
         assert 1 <= v <= 10000, "num_agents must be in [1, 10000]"
         return v
 
-    @validator('obs_radius')
+    @validator("obs_radius")
     def obs_radius_must_be_positive(cls, v):
         assert 1 <= v <= 128, "obs_radius must be in [1, 128]"
         return v
 
-    @validator('map', always=True)
-    def map_validation(cls, v, values, ):
+    @validator("map", always=True)
+    def map_validation(
+        cls,
+        v,
+        values,
+    ):
         if v is None:
             return None
         if isinstance(v, str):
-            v, agents_xy, targets_xy = cls.str_map_to_list(v, values['FREE'], values['OBSTACLE'])
-            if agents_xy and targets_xy and values['agents_xy'] is not None and values['targets_xy'] is not None:
-                raise KeyError("""Can't create task. Please provide agents_xy and targets_xy only ones.
-                Either with parameters or with a map.""")
+            v, agents_xy, targets_xy = cls.str_map_to_list(
+                v, values["FREE"], values["OBSTACLE"]
+            )
+            if (
+                agents_xy
+                and targets_xy
+                and values["agents_xy"] is not None
+                and values["targets_xy"] is not None
+            ):
+                raise KeyError(
+                    """Can't create task. Please provide agents_xy and targets_xy only ones.
+                Either with parameters or with a map."""
+                )
             elif agents_xy and targets_xy:
-                values['agents_xy'] = agents_xy
-                values['targets_xy'] = targets_xy
-                values['num_agents'] = len(agents_xy)
+                values["agents_xy"] = agents_xy
+                values["targets_xy"] = targets_xy
+                values["num_agents"] = len(agents_xy)
         size = len(v)
         area = 0
         for line in v:
             size = max(size, len(line))
             area += len(line)
-        values['size'] = size
-        values['density'] = sum([sum(line) for line in v]) / area
+        values["size"] = size
+        values["density"] = sum([sum(line) for line in v]) / area
         return v
 
-    @validator('agents_xy')
+    @validator("agents_xy")
     def agents_xy_validation(cls, v, values):
         if v is not None:
-            cls.check_positions(v, values['size'])
-            values['num_agents'] = len(v)
+            cls.check_positions(v, values["size"])
+            values["num_agents"] = len(v)
         return v
 
-    @validator('targets_xy')
+    @validator("targets_xy")
     def targets_xy_validation(cls, v, values):
         if v is not None:
-            cls.check_positions(v, values['size'])
-            values['num_agents'] = len(v)
+            cls.check_positions(v, values["size"])
+            values["num_agents"] = len(v)
         return v
 
     @staticmethod
@@ -103,21 +122,23 @@ class GridConfig(CommonSettings, ):
         for idx, line in enumerate(str_map.split()):
             row = []
             for char in line:
-                if char == '.':
+                if char == ".":
                     row.append(free)
-                elif char == '#':
+                elif char == "#":
                     row.append(obstacle)
-                elif 'A' <= char <= 'Z':
+                elif "A" <= char <= "Z":
                     targets[char.lower()] = len(obstacles), len(row)
                     row.append(free)
-                elif 'a' <= char <= 'z':
+                elif "a" <= char <= "z":
                     agents[char.lower()] = len(obstacles), len(row)
                     row.append(free)
                 else:
                     raise KeyError(f"Unsupported symbol '{char}' at line {idx}")
             if row:
                 if obstacles:
-                    assert len(obstacles[-1]) == len(row), f"Wrong string size for row {idx};"
+                    assert len(obstacles[-1]) == len(
+                        row
+                    ), f"Wrong string size for row {idx};"
                 obstacles.append(row)
 
         targets_xy = []
@@ -133,13 +154,15 @@ class GridConfig(CommonSettings, ):
 
 class PredefinedDifficultyConfig(GridConfig):
     density: float = 0.3
-    collision_system: Literal['priority'] = 'priority'
+    collision_system: Literal["priority"] = "priority"
     obs_radius: Literal[5] = 5
-    observation_type: Literal['default'] = 'default'
+    observation_type: Literal["default"] = "default"
 
-    @validator('density', always=True)
+    @validator("density", always=True)
     def density_restrictions(cls, v):
-        assert 0.299999 <= v <= 0.3000001, "density for that predefined configuration must be equal to 0.3"
+        assert (
+            0.299999 <= v <= 0.3000001
+        ), "density for that predefined configuration must be equal to 0.3"
         return v
 
 
@@ -147,109 +170,109 @@ class Easy8x8(PredefinedDifficultyConfig):
     size: Literal[8] = 8
     max_episode_steps: Literal[64] = 64
     num_agents: Literal[1] = 1
-    map_name: Literal['Easy8x8'] = 'Easy8x8'
+    map_name: Literal["Easy8x8"] = "Easy8x8"
 
 
 class Normal8x8(PredefinedDifficultyConfig):
     size: Literal[8] = 8
     max_episode_steps: Literal[64] = 64
     num_agents: Literal[2] = 2
-    map_name: Literal['Normal8x8'] = 'Normal8x8'
+    map_name: Literal["Normal8x8"] = "Normal8x8"
 
 
 class Hard8x8(PredefinedDifficultyConfig):
     size: Literal[8] = 8
     max_episode_steps: Literal[64] = 64
     num_agents: Literal[4] = 4
-    map_name: Literal['Hard8x8'] = 'Hard8x8'
+    map_name: Literal["Hard8x8"] = "Hard8x8"
 
 
 class ExtraHard8x8(PredefinedDifficultyConfig):
     size: Literal[8] = 8
     max_episode_steps: Literal[64] = 64
     num_agents: Literal[8] = 8
-    map_name: Literal['ExtraHard8x8'] = 'ExtraHard8x8'
+    map_name: Literal["ExtraHard8x8"] = "ExtraHard8x8"
 
 
 class Easy16x16(PredefinedDifficultyConfig):
     size: Literal[16] = 16
     max_episode_steps: Literal[128] = 128
     num_agents: Literal[4] = 4
-    map_name: Literal['Easy16x16'] = 'Easy16x16'
+    map_name: Literal["Easy16x16"] = "Easy16x16"
 
 
 class Normal16x16(PredefinedDifficultyConfig):
     size: Literal[16] = 16
     max_episode_steps: Literal[128] = 128
     num_agents: Literal[8] = 8
-    map_name: Literal['Normal16x16'] = 'Normal16x16'
+    map_name: Literal["Normal16x16"] = "Normal16x16"
 
 
 class Hard16x16(PredefinedDifficultyConfig):
     size: Literal[16] = 16
     max_episode_steps: Literal[128] = 128
     num_agents: Literal[16] = 16
-    map_name: Literal['Hard16x16'] = 'Hard16x16'
+    map_name: Literal["Hard16x16"] = "Hard16x16"
 
 
 class ExtraHard16x16(PredefinedDifficultyConfig):
     size: Literal[16] = 16
     max_episode_steps: Literal[128] = 128
     num_agents: Literal[32] = 32
-    map_name: Literal['ExtraHard16x16'] = 'ExtraHard16x16'
+    map_name: Literal["ExtraHard16x16"] = "ExtraHard16x16"
 
 
 class Easy32x32(PredefinedDifficultyConfig):
     size: Literal[32] = 32
     max_episode_steps: Literal[256] = 256
     num_agents: Literal[16] = 16
-    map_name: Literal['Easy32x32'] = 'Easy32x32'
+    map_name: Literal["Easy32x32"] = "Easy32x32"
 
 
 class Normal32x32(PredefinedDifficultyConfig):
     size: Literal[32] = 32
     max_episode_steps: Literal[256] = 256
     num_agents: Literal[32] = 32
-    map_name: Literal['Normal32x32'] = 'Normal32x32'
+    map_name: Literal["Normal32x32"] = "Normal32x32"
 
 
 class Hard32x32(PredefinedDifficultyConfig):
     size: Literal[32] = 32
     max_episode_steps: Literal[256] = 256
     num_agents: Literal[64] = 64
-    map_name: Literal['Hard32x32'] = 'Hard32x32'
+    map_name: Literal["Hard32x32"] = "Hard32x32"
 
 
 class ExtraHard32x32(PredefinedDifficultyConfig):
     size: Literal[32] = 32
     max_episode_steps: Literal[256] = 256
     num_agents: Literal[128] = 128
-    map_name: Literal['ExtraHard32x32'] = 'ExtraHard32x32'
+    map_name: Literal["ExtraHard32x32"] = "ExtraHard32x32"
 
 
 class Easy64x64(PredefinedDifficultyConfig):
     size: Literal[32] = 64
     max_episode_steps: Literal[512] = 512
     num_agents: Literal[16] = 64
-    map_name: Literal['Easy64x64'] = 'Easy64x64'
+    map_name: Literal["Easy64x64"] = "Easy64x64"
 
 
 class Normal64x64(PredefinedDifficultyConfig):
     size: Literal[32] = 64
     max_episode_steps: Literal[512] = 512
     num_agents: Literal[16] = 128
-    map_name: Literal['Normal64x64'] = 'Normal64x64'
+    map_name: Literal["Normal64x64"] = "Normal64x64"
 
 
 class Hard64x64(PredefinedDifficultyConfig):
     size: Literal[32] = 64
     max_episode_steps: Literal[512] = 512
     num_agents: Literal[16] = 256
-    map_name: Literal['Hard64x64'] = 'Hard64x64'
+    map_name: Literal["Hard64x64"] = "Hard64x64"
 
 
 class ExtraHard64x64(PredefinedDifficultyConfig):
     size: Literal[32] = 64
     max_episode_steps: Literal[512] = 512
     num_agents: Literal[16] = 512
-    map_name: Literal['ExtraHard64x64'] = 'ExtraHard64x64'
+    map_name: Literal["ExtraHard64x64"] = "ExtraHard64x64"

--- a/pogema/integrations/jax_intergration.py
+++ b/pogema/integrations/jax_intergration.py
@@ -1,0 +1,106 @@
+try:
+    import jax
+    import jax.numpy as jnp
+except ImportError:
+    print(
+        """To use the integration it's necessary to intall `jax`:
+        https://jax.readthedocs.io/en/latest/installation.html.
+        Terminating.
+    """
+    )
+    exit(-1)
+
+import functools
+from typing import NamedTuple
+
+from pogema import GridConfig
+from pogema.envs import _make_pogema
+
+
+class EnvState(NamedTuple):
+    t: jax.Array
+
+
+def make_step_callback(env):
+    def callback_step(action, env_state):
+        observation, reward, terminated, truncated, info = env.step(
+            action=action.tolist()
+        )
+        return (
+            jnp.array(observation),
+            (env_state + 1).astype(jnp.int32),
+            jnp.array(reward).astype(jnp.float32),
+            jnp.array(terminated).astype(jnp.bool),
+            jnp.array(truncated).astype(jnp.bool),
+            None,  # operating without info
+        )
+
+    return callback_step
+
+
+def make_reset_callback(env):
+    def callback_reset(seed):
+        int_seed = jax.random.randint(seed, (), 0, 1000)
+        observation, _ = env.reset(seed=int_seed)
+        return jnp.array(observation)
+
+    return jax.jit(callback_reset)
+
+
+class PogemaForJax:
+    def __init__(self, grid_config: GridConfig) -> None:
+        self._env = _make_pogema(grid_config)
+
+        self.callback_reset = make_reset_callback(self._env)
+        self.callback_step = make_step_callback(self._env)
+        self.num_agents = self._env.get_num_agents()
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def reset(self, key):
+        def jit_reset(*args):
+            reset_shape = jax.ShapeDtypeStruct(
+                (self.num_agents, *self._env.observation_space.shape), jnp.float32
+            )
+            return jax.pure_callback(self.callback_reset, reset_shape, *args), EnvState(
+                jnp.array(0)
+            )
+
+        return jit_reset(key)
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def step(self, action, env_state):
+
+        def jit_step(*args):
+
+            step_shape = (
+                jax.ShapeDtypeStruct(
+                    (self.num_agents, *self._env.observation_space.shape), jnp.float32
+                ),
+                jax.ShapeDtypeStruct((), jnp.int32),
+                jax.ShapeDtypeStruct((self.num_agents,), jnp.float32),
+                jax.ShapeDtypeStruct((self.num_agents,), jnp.bool),
+                jax.ShapeDtypeStruct((self.num_agents,), jnp.bool),
+                None,
+            )
+            return jax.experimental.io_callback(self.callback_step, step_shape, *args)
+
+        observation, t, reward, terminated, truncated, info = jit_step(
+            action, env_state.t
+        )
+
+        return observation, EnvState(t), reward, terminated, truncated, info
+
+    @property
+    def unwrapped(self):
+        return self._env
+
+    def close(self):
+        pass
+
+    @functools.lru_cache(maxsize=None)
+    def observation_space(self):
+        return self._env.observation_space
+
+    @functools.lru_cache(maxsize=None)
+    def action_space(self):
+        return self._env.action_space

--- a/pogema/integrations/make_pogema.py
+++ b/pogema/integrations/make_pogema.py
@@ -1,12 +1,17 @@
-from typing import Union, Optional
+from typing import Optional, Union
 
 from gymnasium import Wrapper
 
 from pogema import GridConfig
 from pogema.envs import _make_pogema
+from pogema.integrations.jax_intergration import PogemaForJax
 from pogema.integrations.pettingzoo import parallel_env
 from pogema.integrations.pymarl import PyMarlPogema
-from pogema.integrations.sample_factory import AutoResetWrapper, IsMultiAgentWrapper, MetricsForwardingWrapper
+from pogema.integrations.sample_factory import (
+    AutoResetWrapper,
+    IsMultiAgentWrapper,
+    MetricsForwardingWrapper,
+)
 
 
 def _make_sample_factory_integration(grid_config):
@@ -26,10 +31,17 @@ class SingleAgentWrapper(Wrapper):
 
     def step(self, action):
         observations, rewards, terminated, truncated, infos = self.env.step(
-            [action] + [self.env.action_space.sample() for _ in range(self.get_num_agents() - 1)])
+            [action]
+            + [self.env.action_space.sample() for _ in range(self.get_num_agents() - 1)]
+        )
         return observations[0], rewards[0], terminated[0], truncated[0], infos[0]
 
-    def reset(self, seed: Optional[int] = None, return_info: bool = True, options: Optional[dict] = None, ):
+    def reset(
+        self,
+        seed: Optional[int] = None,
+        return_info: bool = True,
+        options: Optional[dict] = None,
+    ):
         observations, infos = self.env.reset()
         if return_info:
             return observations[0], infos[0]
@@ -44,24 +56,30 @@ def make_single_agent_gym(grid_config: Union[GridConfig, dict] = GridConfig()):
     return env
 
 
+def make_pogema_for_jax(grid_config: Union[GridConfig, dict] = GridConfig()):
+    return PogemaForJax(grid_config)
+
+
 def make_pogema(grid_config: Union[GridConfig, dict] = GridConfig(), *args, **kwargs):
     if isinstance(grid_config, dict):
         grid_config = GridConfig(**grid_config)
 
-    if grid_config.integration != 'SampleFactory' and grid_config.auto_reset:
+    if grid_config.integration != "SampleFactory" and grid_config.auto_reset:
         raise KeyError(f"{grid_config.integration} does not support auto_reset")
 
     if grid_config.integration is None:
         return _make_pogema(grid_config)
-    elif grid_config.integration == 'SampleFactory':
+    elif grid_config.integration == "SampleFactory":
         return _make_sample_factory_integration(grid_config)
-    elif grid_config.integration == 'PyMARL':
+    elif grid_config.integration == "PyMARL":
         return _make_py_marl_integration(grid_config, *args, **kwargs)
-    elif grid_config.integration == 'rllib':
-        raise NotImplementedError('Please use PettingZoo integration for rllib')
-    elif grid_config.integration == 'PettingZoo':
+    elif grid_config.integration == "rllib":
+        raise NotImplementedError("Please use PettingZoo integration for rllib")
+    elif grid_config.integration == "PettingZoo":
         return parallel_env(grid_config)
-    elif grid_config.integration == 'gym':
+    elif grid_config.integration == "jax":
+        return make_pogema_for_jax(grid_config)
+    elif grid_config.integration == "gym":
         return make_single_agent_gym(grid_config)
 
     raise KeyError(grid_config.integration)


### PR DESCRIPTION
Usage example
```python
import jax

from pogema import GridConfig, pogema_v0

grid_config = GridConfig(
    size=8,
    num_agents=5,
    obs_radius=2,
    seed=9,
    on_target="finish",
    max_episode_steps=128,
    integration="jax",
)

env = pogema_v0(grid_config=grid_config)


key = jax.random.key(0)

# resetting
state, env_state = env.reset(key)

policy = lambda rng: jax.random.randint(
    rng, (env.num_agents,), minval=0, maxval=env.action_space().n
)

# iteration


def step_fn(carry, _):
    state, env_state, step_key = carry
    act_key, key = jax.random.split(step_key)
    action = policy(act_key)  # random agent
    next_state, new_env_state, reward, terminated, truncated, info = env.step(
        action, env_state
    )
    return (
        (next_state, new_env_state, key),
        (state, next_state, action, reward, terminated, truncated, info),
    )


_, rollout = jax.lax.scan(step_fn, (state, env_state, key), None, length=70)

```